### PR TITLE
CreateInstance: wait until instance is available before return

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -82,11 +82,16 @@ func (c *Client) generateMachineAndIPV4Addresses(req *Setup) ([]string, error) {
 		}
 	}
 
+	return ipv4AddressesFromInstance(instance), nil
+}
+
+func ipv4AddressesFromInstance(instance *compute.Instance) []string {
 	var ipv4Addresses []string
 	for _, netInterface := range instance.NetworkInterfaces {
 		ipv4Addresses = append(ipv4Addresses, netInterface.NetworkIP)
 	}
-	return ipv4Addresses, nil
+	return ipv4Addresses
+
 }
 
 func (c *Client) generateMachine(req *Setup) (*compute.Instance, error) {


### PR DESCRIPTION
CreateInstance creates an initial instance that takes sometime
to boot up before it returns, make sure that the instance
is available before returning otherwise the caller
can get a false start.